### PR TITLE
Improve instrumentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1057,9 +1057,22 @@ dependencies = [
  "byteorder",
  "chrono",
  "diesel_derives",
+ "ipnetwork",
+ "libc",
  "pq-sys",
  "serde_json",
  "uuid 0.8.2",
+]
+
+[[package]]
+name = "diesel-tracing"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee3a3d2f40251a3f814d3ce78d5d3355002fe81f94cdef8d5ca307fdebe62793"
+dependencies = [
+ "diesel",
+ "ipnetwork",
+ "tracing",
 ]
 
 [[package]]
@@ -2116,6 +2129,7 @@ dependencies = [
  "derive-getters",
  "derive_more",
  "diesel",
+ "diesel-tracing",
  "diesel_migrations",
  "domain",
  "dotenv",
@@ -2186,6 +2200,15 @@ name = "ipnet"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f88c5561171189e69df9d98bcf18fd5f9558300f7ea7b801eb8a0fd748bd8745"
+
+[[package]]
+name = "ipnetwork"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4088d739b183546b239688ddbc79891831df421773df95e236daf7867866d355"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "isahc"
@@ -4450,6 +4473,7 @@ name = "testing"
 version = "0.1.0"
 dependencies = [
  "diesel",
+ "diesel-tracing",
  "domain",
  "infrastructure",
  "r2d2",

--- a/backend/api/src/application/payment/process.rs
+++ b/backend/api/src/application/payment/process.rs
@@ -3,9 +3,10 @@ use std::sync::Arc;
 use anyhow::Result;
 use domain::{
 	AggregateRootRepository, Amount, Destination, DomainError, Event, Payment, PaymentId,
-	PaymentReceipt, PaymentReceiptId, Publisher, UniqueMessage,
+	PaymentReceipt, PaymentReceiptId, Publisher,
 };
 use event_store::bus::QUEUE_NAME as EVENT_STORE_QUEUE;
+use infrastructure::amqp::UniqueMessage;
 
 pub struct Usecase {
 	event_publisher: Arc<dyn Publisher<UniqueMessage<Event>>>,

--- a/backend/api/src/application/payment/process.rs
+++ b/backend/api/src/application/payment/process.rs
@@ -7,6 +7,7 @@ use domain::{
 };
 use event_store::bus::QUEUE_NAME as EVENT_STORE_QUEUE;
 use infrastructure::amqp::UniqueMessage;
+use tracing::instrument;
 
 pub struct Usecase {
 	event_publisher: Arc<dyn Publisher<UniqueMessage<Event>>>,
@@ -24,6 +25,7 @@ impl Usecase {
 		}
 	}
 
+	#[instrument(skip(self))]
 	pub async fn add_receipt(
 		&self,
 		payment_id: PaymentId,

--- a/backend/api/src/application/payment/request.rs
+++ b/backend/api/src/application/payment/request.rs
@@ -3,8 +3,9 @@ use std::sync::Arc;
 use anyhow::Result;
 use domain::{
 	AggregateRootRepository, DomainError, Event, GithubUserId, Payment, PaymentId, Project,
-	ProjectEvent, ProjectId, Publisher, UniqueMessage, UserId,
+	ProjectEvent, ProjectId, Publisher, UserId,
 };
+use infrastructure::amqp::UniqueMessage;
 use rusty_money::{crypto, Money};
 use serde_json::Value;
 

--- a/backend/api/src/application/payment/request.rs
+++ b/backend/api/src/application/payment/request.rs
@@ -8,6 +8,7 @@ use domain::{
 use infrastructure::amqp::UniqueMessage;
 use rusty_money::{crypto, Money};
 use serde_json::Value;
+use tracing::instrument;
 
 use crate::domain::Publishable;
 
@@ -27,6 +28,7 @@ impl Usecase {
 		}
 	}
 
+	#[instrument(skip(self))]
 	pub async fn request(
 		&self,
 		project_id: ProjectId,

--- a/backend/api/src/application/project/accept_leader_invitation.rs
+++ b/backend/api/src/application/project/accept_leader_invitation.rs
@@ -2,9 +2,9 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
 use domain::{
-	AggregateRootRepository, DomainError, Event, GithubUserId, Project, Publisher, UniqueMessage,
-	UserId,
+	AggregateRootRepository, DomainError, Event, GithubUserId, Project, Publisher, UserId,
 };
+use infrastructure::amqp::UniqueMessage;
 
 use crate::{
 	domain::{PendingProjectLeaderInvitationId, Publishable},

--- a/backend/api/src/application/project/accept_leader_invitation.rs
+++ b/backend/api/src/application/project/accept_leader_invitation.rs
@@ -5,6 +5,7 @@ use domain::{
 	AggregateRootRepository, DomainError, Event, GithubUserId, Project, Publisher, UserId,
 };
 use infrastructure::amqp::UniqueMessage;
+use tracing::instrument;
 
 use crate::{
 	domain::{PendingProjectLeaderInvitationId, Publishable},
@@ -30,6 +31,7 @@ impl Usecase {
 		}
 	}
 
+	#[instrument(skip(self))]
 	pub async fn accept_leader_invitation(
 		&self,
 		invitation_id: &PendingProjectLeaderInvitationId,

--- a/backend/api/src/application/project/create.rs
+++ b/backend/api/src/application/project/create.rs
@@ -6,6 +6,7 @@ use domain::{
 	ProjectEvent, ProjectId, Publisher,
 };
 use infrastructure::amqp::UniqueMessage;
+use tracing::instrument;
 
 use crate::{
 	domain::{ProjectDetails, Publishable},
@@ -32,6 +33,7 @@ impl Usecase {
 	}
 
 	#[allow(clippy::too_many_arguments)]
+	#[instrument(skip(self))]
 	pub async fn create(
 		&self,
 		name: String,

--- a/backend/api/src/application/project/create.rs
+++ b/backend/api/src/application/project/create.rs
@@ -3,8 +3,9 @@ use std::sync::Arc;
 use anyhow::Result;
 use domain::{
 	Amount, Budget, BudgetId, DomainError, Event, GithubRepoExists, GithubRepositoryId, Project,
-	ProjectEvent, ProjectId, Publisher, UniqueMessage,
+	ProjectEvent, ProjectId, Publisher,
 };
+use infrastructure::amqp::UniqueMessage;
 
 use crate::{
 	domain::{ProjectDetails, Publishable},

--- a/backend/api/src/application/project/invite_leader.rs
+++ b/backend/api/src/application/project/invite_leader.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use domain::{DomainError, GithubUserId, ProjectId};
+use tracing::instrument;
 
 use crate::{
 	domain::{PendingProjectLeaderInvitation, PendingProjectLeaderInvitationId},
@@ -19,6 +20,7 @@ impl Usecase {
 		}
 	}
 
+	#[instrument(skip(self))]
 	pub async fn invite_leader(
 		&self,
 		project_id: ProjectId,

--- a/backend/api/src/application/project/remove_leader.rs
+++ b/backend/api/src/application/project/remove_leader.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
 use domain::{
-	AggregateRootRepository, Destination, DomainError, Event, Project, ProjectId, Publisher,
-	UniqueMessage, UserId,
+	AggregateRootRepository, Destination, DomainError, Event, Project, ProjectId, Publisher, UserId,
 };
 use event_store::bus::QUEUE_NAME as EVENT_STORE_QUEUE;
+use infrastructure::amqp::UniqueMessage;
 
 pub struct Usecase {
 	event_publisher: Arc<dyn Publisher<UniqueMessage<Event>>>,

--- a/backend/api/src/application/project/remove_leader.rs
+++ b/backend/api/src/application/project/remove_leader.rs
@@ -5,6 +5,7 @@ use domain::{
 };
 use event_store::bus::QUEUE_NAME as EVENT_STORE_QUEUE;
 use infrastructure::amqp::UniqueMessage;
+use tracing::instrument;
 
 pub struct Usecase {
 	event_publisher: Arc<dyn Publisher<UniqueMessage<Event>>>,
@@ -22,6 +23,7 @@ impl Usecase {
 		}
 	}
 
+	#[instrument(skip(self))]
 	pub async fn remove_leader(
 		&self,
 		project_id: &ProjectId,

--- a/backend/api/src/application/project/update_github_repo_id.rs
+++ b/backend/api/src/application/project/update_github_repo_id.rs
@@ -6,6 +6,7 @@ use domain::{
 	ProjectId, Publisher,
 };
 use infrastructure::amqp::UniqueMessage;
+use tracing::instrument;
 
 use crate::domain::Publishable;
 
@@ -28,6 +29,7 @@ impl Usecase {
 		}
 	}
 
+	#[instrument(skip(self))]
 	pub async fn update_project_github_repo_id(
 		&self,
 		project_id: ProjectId,

--- a/backend/api/src/application/project/update_github_repo_id.rs
+++ b/backend/api/src/application/project/update_github_repo_id.rs
@@ -3,8 +3,9 @@ use std::sync::Arc;
 use anyhow::Result;
 use domain::{
 	AggregateRootRepository, DomainError, Event, GithubRepoExists, GithubRepositoryId, Project,
-	ProjectId, Publisher, UniqueMessage,
+	ProjectId, Publisher,
 };
+use infrastructure::amqp::UniqueMessage;
 
 use crate::domain::Publishable;
 

--- a/backend/api/src/presentation/graphql/context.rs
+++ b/backend/api/src/presentation/graphql/context.rs
@@ -1,11 +1,8 @@
 use std::sync::Arc;
 
 use derive_getters::Getters;
-use domain::{
-	AggregateRootRepository, Event, GithubUserId, Payment, Project, Publisher, UniqueMessage,
-	UserId,
-};
-use infrastructure::github;
+use domain::{AggregateRootRepository, Event, GithubUserId, Payment, Project, Publisher, UserId};
+use infrastructure::{amqp::UniqueMessage, github};
 use presentation::http::guards::OptionUserId;
 
 use super::{Error, Result};

--- a/backend/api/src/presentation/graphql/error.rs
+++ b/backend/api/src/presentation/graphql/error.rs
@@ -1,6 +1,7 @@
 use domain::{DomainError, UserId};
 use infrastructure::database::DatabaseError;
 use juniper::{graphql_value, DefaultScalarValue, FieldError, IntoFieldError};
+use olog::error;
 use thiserror::Error;
 
 use crate::application::user::update_profile_info::Error as UpdateProfileInfoError;
@@ -49,6 +50,8 @@ impl From<UpdateProfileInfoError> for Error {
 
 impl IntoFieldError for Error {
 	fn into_field_error(self) -> FieldError<DefaultScalarValue> {
+		error!(error = format!("{self:?}"), "Error occured");
+
 		let (msg, reason) = match &self {
 			Self::NotAuthenticated(reason) => (self.to_string(), reason.clone()),
 			Self::NotAuthorized(_, reason) => (self.to_string(), reason.clone()),

--- a/backend/api/src/presentation/graphql/query.rs
+++ b/backend/api/src/presentation/graphql/query.rs
@@ -1,5 +1,4 @@
 use juniper::graphql_object;
-use tracing::instrument;
 
 use super::Context;
 
@@ -12,15 +11,6 @@ impl Query {
 	}
 
 	pub fn hello(&self) -> &str {
-		InstrumentableQuery::hello()
-	}
-}
-
-pub struct InstrumentableQuery;
-
-impl InstrumentableQuery {
-	#[instrument]
-	pub fn hello() -> &'static str {
 		olog::info!("So hungry!");
 		"Couscous!"
 	}

--- a/backend/api/src/presentation/http/mod.rs
+++ b/backend/api/src/presentation/http/mod.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
-use ::domain::{AggregateRootRepository, Event, Payment, Project, Publisher, UniqueMessage};
+use ::domain::{AggregateRootRepository, Event, Payment, Project, Publisher};
 use anyhow::Result;
 use http::Config;
-use infrastructure::{github, web3::ens};
+use infrastructure::{amqp::UniqueMessage, github, web3::ens};
 use presentation::http;
 
 use crate::{

--- a/backend/api/src/presentation/http/routes/graphql.rs
+++ b/backend/api/src/presentation/http/routes/graphql.rs
@@ -5,6 +5,7 @@ use infrastructure::github;
 use juniper_rocket::{GraphQLRequest, GraphQLResponse};
 use presentation::http::guards::{ApiKey, ApiKeyGuard, OptionUserId, Role};
 use rocket::{response::content, State};
+use tracing::instrument;
 
 use crate::{
 	infrastructure::{
@@ -32,6 +33,7 @@ pub fn graphiql() -> content::RawHtml<String> {
 
 #[allow(clippy::too_many_arguments)]
 #[get("/graphql?<request>")]
+#[instrument(skip_all, fields(user.ids = debug(&maybe_user_id), user.role = debug(&role), graphql_request = debug(&request)))]
 pub async fn get_graphql_handler(
 	_api_key: ApiKeyGuard<GraphqlApiKey>,
 	role: Role,
@@ -66,6 +68,7 @@ pub async fn get_graphql_handler(
 
 #[allow(clippy::too_many_arguments)]
 #[post("/graphql", data = "<request>")]
+#[instrument(skip_all, fields(user.ids = debug(&maybe_user_id), user.role = debug(&role), graphql_request = debug(&request)))]
 pub async fn post_graphql_handler(
 	_api_key: ApiKeyGuard<GraphqlApiKey>,
 	role: Role,

--- a/backend/api/src/presentation/http/routes/graphql.rs
+++ b/backend/api/src/presentation/http/routes/graphql.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
-use domain::{AggregateRootRepository, Event, Payment, Project, Publisher, UniqueMessage};
-use infrastructure::github;
+use domain::{AggregateRootRepository, Event, Payment, Project, Publisher};
+use infrastructure::{amqp::UniqueMessage, github};
 use juniper_rocket::{GraphQLRequest, GraphQLResponse};
 use presentation::http::guards::{ApiKey, ApiKeyGuard, OptionUserId, Role};
 use rocket::{response::content, State};

--- a/backend/common/derive/src/diesel_mapping_repository.rs
+++ b/backend/common/derive/src/diesel_mapping_repository.rs
@@ -47,6 +47,10 @@ pub fn impl_diesel_mapping_repository(input: syn::DeriveInput) -> TokenStream {
 	let (entity1, entity2) = find_entities(&input);
 	let (id1, id2) = find_ids(&input);
 
+	let table_ident = &table.path.segments.last().unwrap().ident;
+	let insert_span_name = format!("{}::insert", table_ident);
+	let delete_span_name = format!("{}::delete", table_ident);
+
 	// Build the output, possibly using quasi-quotation
 	let expanded = quote! {
 		use diesel::RunQueryDsl;
@@ -55,6 +59,7 @@ pub fn impl_diesel_mapping_repository(input: syn::DeriveInput) -> TokenStream {
 		use diesel::query_dsl::filter_dsl::FindDsl;
 
 		impl infrastructure::database::MappingRepository<#entity1, #entity2> for #repository_name {
+			#[tracing::instrument(name = #insert_span_name, skip(self))]
 			fn insert(&self, id1: &<#entity1 as domain::Entity>::Id, id2: &<#entity2 as domain::Entity>::Id) -> Result<(), infrastructure::database::DatabaseError> {
 				let connection = self.0.connection()?;
 
@@ -65,6 +70,7 @@ pub fn impl_diesel_mapping_repository(input: syn::DeriveInput) -> TokenStream {
 				Ok(())
 			}
 
+			#[tracing::instrument(name = #delete_span_name, skip(self))]
 			fn delete(&self, id1: &<#entity1 as domain::Entity>::Id, id2: &<#entity2 as domain::Entity>::Id) -> Result<(), infrastructure::database::DatabaseError> {
 				let connection = self.0.connection()?;
 

--- a/backend/common/derive/src/diesel_repository.rs
+++ b/backend/common/derive/src/diesel_repository.rs
@@ -11,6 +11,14 @@ pub fn impl_diesel_repository(derive_input: syn::DeriveInput) -> TokenStream {
 	let table: TypePath = find_attr(&derive_input, "table");
 	let id: TypePath = find_attr(&derive_input, "id");
 
+	let table_ident = &table.path.segments.last().unwrap().ident;
+	let find_by_id_span_name = format!("{}::find_by_id", table_ident);
+	let insert_span_name = format!("{}::insert", table_ident);
+	let update_span_name = format!("{}::update", table_ident);
+	let upsert_span_name = format!("{}::upsert", table_ident);
+	let delete_span_name = format!("{}::delete", table_ident);
+	let clear_span_name = format!("{}::clear", table_ident);
+
 	// Build the output, possibly using quasi-quotation
 	let expanded = quote! {
 		use diesel::RunQueryDsl;
@@ -20,27 +28,31 @@ pub fn impl_diesel_repository(derive_input: syn::DeriveInput) -> TokenStream {
 		use diesel::pg::Pg;
 
 		impl #repository_name {
+			#[tracing::instrument(name = #find_by_id_span_name, skip(self))]
 			pub fn find_by_id(&self, id: <&#entity_type as ::domain::Entity>::Id) -> Result<#entity_type, infrastructure::database::DatabaseError> {
 				let connection = self.0.connection()?;
 				let entity = #table.find(*id).first(&*connection)?;
 				Ok(entity)
 			}
 
+			#[tracing::instrument(name = #insert_span_name, skip(self))]
 			pub fn insert(&self, entity: &#entity_type) -> Result<(), infrastructure::database::DatabaseError> {
 				let connection = self.0.connection()?;
 				diesel::insert_into(#table).values(entity).execute(&*connection)?;
 				Ok(())
 			}
 
-			pub fn update<A: AsChangeset<Target = #table, Changeset = C>, C: QueryFragment<Pg>>(&self, id: <&#entity_type as ::domain::Entity>::Id, entity: A) -> Result<(), infrastructure::database::DatabaseError> {
+			#[tracing::instrument(name = #update_span_name, skip(self, change_set))]
+			pub fn update<A: AsChangeset<Target = #table, Changeset = C>, C: QueryFragment<Pg>>(&self, id: <&#entity_type as ::domain::Entity>::Id, change_set: A) -> Result<(), infrastructure::database::DatabaseError> {
 				let connection = self.0.connection()?;
 				diesel::update(#table)
 					.filter(#id.eq(id))
-					.set(entity)
+					.set(change_set)
 					.execute(&*connection)?;
 				Ok(())
 			}
 
+			#[tracing::instrument(name = #upsert_span_name, skip(self))]
 			pub fn upsert(&self, entity: &#entity_type)  -> Result<(), infrastructure::database::DatabaseError> {
 				let connection = self.0.connection()?;
 				diesel::insert_into(#table)
@@ -52,12 +64,14 @@ pub fn impl_diesel_repository(derive_input: syn::DeriveInput) -> TokenStream {
 				Ok(())
 			}
 
+			#[tracing::instrument(name = #delete_span_name, skip(self))]
 			pub fn delete(&self, id: <&#entity_type as ::domain::Entity>::Id) -> Result<(), infrastructure::database::DatabaseError> {
 				let connection = self.0.connection()?;
 				diesel::delete(#table).filter(#id.eq(id)).execute(&*connection)?;
 				Ok(())
 			}
 
+			#[tracing::instrument(name = #clear_span_name, skip(self))]
 			pub fn clear(&self) -> Result<(), infrastructure::database::DatabaseError> {
 				let connection = self.0.connection()?;
 				diesel::delete(#table).execute(&*connection)?;

--- a/backend/common/domain/src/event.rs
+++ b/backend/common/domain/src/event.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{Message, PaymentEvent, ProjectEvent};
+use crate::{MessagePayload, PaymentEvent, ProjectEvent};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Event {
@@ -20,7 +20,7 @@ impl Display for Event {
 	}
 }
 
-impl Message for Event {}
+impl MessagePayload for Event {}
 
 #[cfg(test)]
 mod test {

--- a/backend/common/domain/src/lib.rs
+++ b/backend/common/domain/src/lib.rs
@@ -16,7 +16,7 @@ pub use error::*;
 mod messaging;
 pub use messaging::{
 	Destination, Message, Payload as MessagePayload, Publisher, PublisherError, Subscriber,
-	SubscriberCallbackError, SubscriberError, UniqueMessage,
+	SubscriberCallbackError, SubscriberError,
 };
 
 mod project;

--- a/backend/common/domain/src/lib.rs
+++ b/backend/common/domain/src/lib.rs
@@ -15,8 +15,8 @@ pub use error::*;
 
 mod messaging;
 pub use messaging::{
-	Destination, Message, Publisher, PublisherError, Subscriber, SubscriberCallbackError,
-	SubscriberError, UniqueMessage,
+	Destination, Message, Payload as MessagePayload, Publisher, PublisherError, Subscriber,
+	SubscriberCallbackError, SubscriberError, UniqueMessage,
 };
 
 mod project;

--- a/backend/common/domain/src/messaging/message.rs
+++ b/backend/common/domain/src/messaging/message.rs
@@ -1,68 +1,7 @@
-use std::{
-	collections::HashMap,
-	fmt::{Debug, Display},
-};
+use std::fmt::Debug;
 
-use chrono::{NaiveDateTime, Utc};
-use derive_getters::Getters;
-use olog::{
-	opentelemetry::{
-		propagation::{Extractor, TextMapPropagator},
-		sdk::propagation::TraceContextPropagator,
-	},
-	tracing_opentelemetry::OpenTelemetrySpanExt,
-};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use serde_json::Value;
-use tracing::Span;
-use uuid::Uuid;
+use olog::opentelemetry::propagation::Extractor;
+use serde::{de::DeserializeOwned, Serialize};
 
 pub trait Message: Extractor + Serialize + DeserializeOwned + Debug + Clone {}
 pub trait Payload: Serialize + DeserializeOwned + Debug + Clone {}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Getters)]
-pub struct UniqueMessage<P> {
-	id: Uuid,
-	timestamp: NaiveDateTime,
-	metadata: Value,
-	payload: P,
-	trace_context: HashMap<String, String>,
-}
-
-impl<P> Extractor for UniqueMessage<P> {
-	fn get(&self, key: &str) -> Option<&str> {
-		Extractor::get(&self.trace_context, key)
-	}
-
-	fn keys(&self) -> Vec<&str> {
-		Extractor::keys(&self.trace_context)
-	}
-}
-
-impl<P: Payload> Message for UniqueMessage<P> {}
-
-impl<P> UniqueMessage<P> {
-	pub fn new(payload: P) -> Self {
-		let mut trace_context = HashMap::new();
-		TraceContextPropagator::new()
-			.inject_context(&Span::current().context(), &mut trace_context);
-		Self {
-			id: Uuid::new_v4(),
-			payload,
-			timestamp: Utc::now().naive_utc(),
-			metadata: Default::default(),
-			trace_context,
-		}
-	}
-}
-
-impl<P: Serialize> Display for UniqueMessage<P> {
-	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		write!(
-			f,
-			"{}",
-			serde_json::to_string(self).map_err(|_| std::fmt::Error)?
-		)?;
-		Ok(())
-	}
-}

--- a/backend/common/domain/src/messaging/message.rs
+++ b/backend/common/domain/src/messaging/message.rs
@@ -1,12 +1,24 @@
-use std::fmt::{Debug, Display};
+use std::{
+	collections::HashMap,
+	fmt::{Debug, Display},
+};
 
 use chrono::{NaiveDateTime, Utc};
 use derive_getters::Getters;
+use olog::{
+	opentelemetry::{
+		propagation::{Extractor, TextMapPropagator},
+		sdk::propagation::TraceContextPropagator,
+	},
+	tracing_opentelemetry::OpenTelemetrySpanExt,
+};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value;
+use tracing::Span;
 use uuid::Uuid;
 
-pub trait Message: Serialize + DeserializeOwned + Debug + Clone {}
+pub trait Message: Extractor + Serialize + DeserializeOwned + Debug + Clone {}
+pub trait Payload: Serialize + DeserializeOwned + Debug + Clone {}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Getters)]
 pub struct UniqueMessage<P> {
@@ -14,17 +26,32 @@ pub struct UniqueMessage<P> {
 	timestamp: NaiveDateTime,
 	metadata: Value,
 	payload: P,
+	trace_context: HashMap<String, String>,
 }
 
-impl<P: Message> Message for UniqueMessage<P> {}
+impl<P> Extractor for UniqueMessage<P> {
+	fn get(&self, key: &str) -> Option<&str> {
+		Extractor::get(&self.trace_context, key)
+	}
+
+	fn keys(&self) -> Vec<&str> {
+		Extractor::keys(&self.trace_context)
+	}
+}
+
+impl<P: Payload> Message for UniqueMessage<P> {}
 
 impl<P> UniqueMessage<P> {
 	pub fn new(payload: P) -> Self {
+		let mut trace_context = HashMap::new();
+		TraceContextPropagator::new()
+			.inject_context(&Span::current().context(), &mut trace_context);
 		Self {
 			id: Uuid::new_v4(),
 			payload,
 			timestamp: Utc::now().naive_utc(),
 			metadata: Default::default(),
+			trace_context,
 		}
 	}
 }

--- a/backend/common/domain/src/messaging/mod.rs
+++ b/backend/common/domain/src/messaging/mod.rs
@@ -1,5 +1,5 @@
 mod message;
-pub use message::{Message, UniqueMessage};
+pub use message::{Message, Payload, UniqueMessage};
 
 mod publisher;
 pub use publisher::{Error as PublisherError, Publisher};

--- a/backend/common/domain/src/messaging/mod.rs
+++ b/backend/common/domain/src/messaging/mod.rs
@@ -1,5 +1,5 @@
 mod message;
-pub use message::{Message, Payload, UniqueMessage};
+pub use message::{Message, Payload};
 
 mod publisher;
 pub use publisher::{Error as PublisherError, Publisher};

--- a/backend/common/domain/src/messaging/publisher.rs
+++ b/backend/common/domain/src/messaging/publisher.rs
@@ -31,6 +31,7 @@ pub trait Publisher<M: Message + Sync + Send>: Send + Sync {
 mod tests {
 	use futures::FutureExt;
 	use mockall::predicate::eq;
+	use olog::opentelemetry::propagation::Extractor;
 	use rstest::rstest;
 	use serde::{Deserialize, Serialize};
 
@@ -55,7 +56,15 @@ mod tests {
 			self.0.publish(destination, message).await
 		}
 	}
+	impl Extractor for TestMessage {
+		fn get(&self, _key: &str) -> Option<&str> {
+			None
+		}
 
+		fn keys(&self) -> Vec<&str> {
+			Vec::default()
+		}
+	}
 	impl Message for TestMessage {}
 
 	#[rstest]

--- a/backend/common/infrastructure/Cargo.toml
+++ b/backend/common/infrastructure/Cargo.toml
@@ -59,6 +59,7 @@ opentelemetry-datadog = {version = "0.6.0", features = ["reqwest-client"]}
 tracing = "0.1"
 tracing-opentelemetry = "0.18.0"
 tracing-subscriber = {version = "0.3", features = ["env-filter", "fmt", "json"]}
+diesel-tracing = {version = "0.1.6", features = ["postgres"]}
 
 # Errors
 anyhow = "1.0.57"

--- a/backend/common/infrastructure/graphql/query_find_user.graphql
+++ b/backend/common/infrastructure/graphql/query_find_user.graphql
@@ -1,5 +1,0 @@
-query FindUserQuery($userId: uuid!) {
-    user(id: $userId) {
-        displayName
-    }
-}

--- a/backend/common/infrastructure/src/amqp/mod.rs
+++ b/backend/common/infrastructure/src/amqp/mod.rs
@@ -6,3 +6,6 @@ pub use config::Config;
 
 mod publisher;
 mod subscriber;
+
+mod unique_message;
+pub use unique_message::UniqueMessage;

--- a/backend/common/infrastructure/src/amqp/unique_message.rs
+++ b/backend/common/infrastructure/src/amqp/unique_message.rs
@@ -1,0 +1,66 @@
+use std::{
+	collections::HashMap,
+	fmt::{Debug, Display},
+};
+
+use chrono::{NaiveDateTime, Utc};
+use derive_getters::Getters;
+use domain::{Message, MessagePayload};
+use olog::{
+	opentelemetry::{
+		propagation::{Extractor, TextMapPropagator},
+		sdk::propagation::TraceContextPropagator,
+	},
+	tracing_opentelemetry::OpenTelemetrySpanExt,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tracing::Span;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Getters)]
+pub struct UniqueMessage<P> {
+	id: Uuid,
+	timestamp: NaiveDateTime,
+	metadata: Value,
+	payload: P,
+	trace_context: HashMap<String, String>,
+}
+
+impl<P> Extractor for UniqueMessage<P> {
+	fn get(&self, key: &str) -> Option<&str> {
+		Extractor::get(&self.trace_context, key)
+	}
+
+	fn keys(&self) -> Vec<&str> {
+		Extractor::keys(&self.trace_context)
+	}
+}
+
+impl<P: MessagePayload> Message for UniqueMessage<P> {}
+
+impl<P> UniqueMessage<P> {
+	pub fn new(payload: P) -> Self {
+		let mut trace_context = HashMap::new();
+		TraceContextPropagator::new()
+			.inject_context(&Span::current().context(), &mut trace_context);
+		Self {
+			id: Uuid::new_v4(),
+			payload,
+			timestamp: Utc::now().naive_utc(),
+			metadata: Default::default(),
+			trace_context,
+		}
+	}
+}
+
+impl<P: Serialize> Display for UniqueMessage<P> {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		write!(
+			f,
+			"{}",
+			serde_json::to_string(self).map_err(|_| std::fmt::Error)?
+		)?;
+		Ok(())
+	}
+}

--- a/backend/common/infrastructure/src/database/mod.rs
+++ b/backend/common/infrastructure/src/database/mod.rs
@@ -1,11 +1,11 @@
 pub mod schema;
 
 mod error;
+use diesel_tracing::pg::InstrumentedPgConnection;
 pub use error::Error as DatabaseError;
 
 mod config;
 pub use config::Config;
-use diesel::PgConnection;
 use olog::error;
 use r2d2;
 use r2d2_diesel::ConnectionManager;
@@ -13,8 +13,8 @@ use r2d2_diesel::ConnectionManager;
 mod mapping;
 pub use mapping::Repository as MappingRepository;
 
-type Pool = r2d2::Pool<ConnectionManager<PgConnection>>;
-type PooledConnection = r2d2::PooledConnection<ConnectionManager<PgConnection>>;
+type Pool = r2d2::Pool<ConnectionManager<InstrumentedPgConnection>>;
+type PooledConnection = r2d2::PooledConnection<ConnectionManager<InstrumentedPgConnection>>;
 
 pub fn run_migrations(pool: &Pool) {
 	let connection = pool.get().expect("Unable to get connection from pool");
@@ -50,7 +50,7 @@ impl Client {
 }
 
 pub fn init_pool(config: &Config) -> Result<Pool, DatabaseError> {
-	let manager = ConnectionManager::<PgConnection>::new(config.url());
+	let manager = ConnectionManager::<InstrumentedPgConnection>::new(config.url());
 	let pool = Pool::builder().max_size(*config.pool_max_size()).build(manager)?;
 
 	Ok(pool)

--- a/backend/common/testing/Cargo.toml
+++ b/backend/common/testing/Cargo.toml
@@ -15,6 +15,9 @@ diesel = {version = "1.4.8", default-features = false, features = [
 r2d2 = "0.8.10"
 r2d2-diesel = "1.0.0"
 
+# Tracing
+diesel-tracing = {version = "0.1.6", features = ["postgres"]}
+
 # Utils
 uuid = {version = "0.8.2", default_features = false, features = [
   "v4",

--- a/backend/common/testing/src/lib.rs
+++ b/backend/common/testing/src/lib.rs
@@ -1,13 +1,14 @@
 pub mod fixtures;
 
-use diesel::{Connection, PgConnection};
+use diesel::Connection;
+use diesel_tracing::pg::InstrumentedPgConnection;
 use r2d2_diesel::ConnectionManager;
-type Pool = r2d2::Pool<ConnectionManager<PgConnection>>;
+type Pool = r2d2::Pool<ConnectionManager<InstrumentedPgConnection>>;
 
 use infrastructure::database;
 
 pub fn init_pool(config: &database::Config) -> Pool {
-	let manager = ConnectionManager::<PgConnection>::new(config.url());
+	let manager = ConnectionManager::<InstrumentedPgConnection>::new(config.url());
 	let pool = Pool::builder().max_size(1).build(manager).unwrap();
 	pool.get().unwrap().begin_test_transaction().unwrap();
 	pool

--- a/backend/event-listeners/src/domain/projectors/budget.rs
+++ b/backend/event-listeners/src/domain/projectors/budget.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use derive_more::Constructor;
 use domain::{BudgetEvent, Event, ProjectEvent, SubscriberCallbackError};
+use tracing::instrument;
 
 use crate::{
 	domain::{Budget, EventListener},
@@ -15,6 +16,7 @@ pub struct Projector {
 
 #[async_trait]
 impl EventListener for Projector {
+	#[instrument(name = "budget_projection", skip(self))]
 	async fn on_event(&self, event: &Event) -> Result<(), SubscriberCallbackError> {
 		if let Event::Project(ProjectEvent::Budget {
 			id: project_id,

--- a/backend/event-listeners/src/domain/projectors/payment.rs
+++ b/backend/event-listeners/src/domain/projectors/payment.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use domain::{Event, PaymentEvent, SubscriberCallbackError};
+use tracing::instrument;
 
 use crate::{
 	domain::{EventListener, Payment},
@@ -19,6 +20,7 @@ impl Projector {
 
 #[async_trait]
 impl EventListener for Projector {
+	#[instrument(name = "payment_projection", skip(self))]
 	async fn on_event(&self, event: &Event) -> Result<(), SubscriberCallbackError> {
 		if let Event::Payment(PaymentEvent::Processed {
 			id,

--- a/backend/event-listeners/src/domain/projectors/payment_request.rs
+++ b/backend/event-listeners/src/domain/projectors/payment_request.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use domain::{Event, PaymentEvent, SubscriberCallbackError};
+use tracing::instrument;
 
 use crate::{
 	domain::{EventListener, PaymentRequest},
@@ -19,6 +20,7 @@ impl Projector {
 
 #[async_trait]
 impl EventListener for Projector {
+	#[instrument(name = "payment_request_projection", skip(self))]
 	async fn on_event(&self, event: &Event) -> Result<(), SubscriberCallbackError> {
 		if let Event::Payment(PaymentEvent::Requested {
 			id,

--- a/backend/event-listeners/src/domain/projectors/project.rs
+++ b/backend/event-listeners/src/domain/projectors/project.rs
@@ -57,6 +57,7 @@ impl Projector {
 
 #[async_trait]
 impl EventListener for Projector {
+	#[instrument(name = "project_projection", skip(self))]
 	async fn on_event(&self, event: &Event) -> Result<(), SubscriberCallbackError> {
 		if let Event::Project(event) = event {
 			match event {

--- a/backend/event-listeners/src/presentation/listeners/mod.rs
+++ b/backend/event-listeners/src/presentation/listeners/mod.rs
@@ -5,8 +5,11 @@ mod webhook;
 use std::sync::Arc;
 
 use anyhow::Result;
-use domain::{Event, Subscriber, SubscriberCallbackError, UniqueMessage};
-use infrastructure::{amqp::ConsumableBus, database, event_bus, github};
+use domain::{Event, Subscriber, SubscriberCallbackError};
+use infrastructure::{
+	amqp::{ConsumableBus, UniqueMessage},
+	database, event_bus, github,
+};
 use tokio::task::JoinHandle;
 use webhook::EventWebHook;
 

--- a/backend/event-listeners/src/presentation/listeners/webhook.rs
+++ b/backend/event-listeners/src/presentation/listeners/webhook.rs
@@ -6,6 +6,7 @@ use domain::{Event, SubscriberCallbackError};
 use olog::{error, info};
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use serde_json::json;
+use tracing::instrument;
 use url::Url;
 
 use crate::domain::EventListener;
@@ -93,6 +94,7 @@ impl EventListener for EventWebHook {
 	}
 }
 
+#[instrument(skip(client))]
 async fn send_event_to_webhook(client: &reqwest::Client, event: &Event) -> Result<(), Error> {
 	let env_var = std::env::var(WEBHOOK_TARGET_ENV_VAR).map_err(Error::EnvVarNotSet)?;
 	let target = Url::parse(&env_var).map_err(Error::InvalidEnvVar)?;

--- a/backend/event-store/src/domain/store.rs
+++ b/backend/event-store/src/domain/store.rs
@@ -1,4 +1,5 @@
-use backend_domain::{Event, UniqueMessage};
+use backend_domain::Event;
+use backend_infrastructure::amqp::UniqueMessage;
 use thiserror::Error;
 
 #[derive(Debug, Error)]

--- a/backend/event-store/src/infrastructure/database/store.rs
+++ b/backend/event-store/src/infrastructure/database/store.rs
@@ -9,6 +9,7 @@ use backend_infrastructure::{
 use diesel::{dsl::exists, prelude::*};
 use olog::error;
 use serde_json::{to_value as to_json, Value as Json};
+use tracing::instrument;
 
 use crate::{domain::*, infrastructure::database::models};
 
@@ -29,6 +30,7 @@ impl NamedAggregate for Event {
 }
 
 impl EventStore for Client {
+	#[instrument(name = "EventStore::append", skip(self))]
 	fn append(&self, aggregate_id: &str, storable_event: UniqueMessage<Event>) -> Result<()> {
 		let connection = self.connection().map_err(|e| {
 			error!("Failed to connect to database: {e}");

--- a/backend/event-store/src/infrastructure/database/store.rs
+++ b/backend/event-store/src/infrastructure/database/store.rs
@@ -1,7 +1,10 @@
-use backend_domain::{Event, UniqueMessage};
-use backend_infrastructure::database::{
-	schema::{event_deduplications, event_deduplications::dsl, events, events::index},
-	Client,
+use backend_domain::Event;
+use backend_infrastructure::{
+	amqp::UniqueMessage,
+	database::{
+		schema::{event_deduplications, event_deduplications::dsl, events, events::index},
+		Client,
+	},
 };
 use diesel::{dsl::exists, prelude::*};
 use olog::error;

--- a/backend/event-store/src/main.rs
+++ b/backend/event-store/src/main.rs
@@ -58,10 +58,11 @@ async fn store(
 
 async fn publish(
 	message: UniqueMessage<Event>,
-	publisher: Arc<dyn Publisher<Event>>,
+	publisher: Arc<dyn Publisher<UniqueMessage<Event>>>,
 ) -> Result<(), SubscriberCallbackError> {
+	let message = UniqueMessage::new(message.payload().clone());
 	publisher
-		.publish(Destination::exchange(EXCHANGE_NAME), message.payload())
+		.publish(Destination::exchange(EXCHANGE_NAME), &message)
 		.await
 		.map_err(|e| SubscriberCallbackError::Fatal(e.into()))?;
 	Ok(())

--- a/backend/event-store/src/main.rs
+++ b/backend/event-store/src/main.rs
@@ -2,11 +2,9 @@ use std::sync::Arc;
 
 use ::olog::info;
 use anyhow::Result;
-use backend_domain::{
-	Destination, Event, Publisher, Subscriber, SubscriberCallbackError, UniqueMessage,
-};
+use backend_domain::{Destination, Event, Publisher, Subscriber, SubscriberCallbackError};
 use backend_infrastructure::{
-	amqp::{self, Bus},
+	amqp::{self, Bus, UniqueMessage},
 	config,
 	database::{self, init_pool, Client as DatabaseClient},
 	event_bus::EXCHANGE_NAME,

--- a/backend/github-proxy/src/presentation/http/mod.rs
+++ b/backend/github-proxy/src/presentation/http/mod.rs
@@ -18,8 +18,8 @@ pub async fn serve(config: http::Config, github_service: Arc<dyn GithubService>)
 			"/",
 			routes![
 				routes::graphql::graphiql,
-				routes::graphql::get,
-				routes::graphql::post
+				routes::graphql::get_graphql_handler,
+				routes::graphql::post_graphql_handler
 			],
 		)
 		.launch()

--- a/backend/github-proxy/src/presentation/http/routes/graphql.rs
+++ b/backend/github-proxy/src/presentation/http/routes/graphql.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use juniper_rocket::{GraphQLRequest, GraphQLResponse};
 use presentation::http::guards::{ApiKey, ApiKeyGuard};
 use rocket::{response::content, State};
+use tracing::instrument;
 
 use crate::{domain::GithubService, presentation::graphql};
 
@@ -20,7 +21,8 @@ impl ApiKey for GraphqlApiKey {
 }
 
 #[get("/graphql?<request>")]
-pub async fn get(
+#[instrument(skip_all, fields(graphql_request = debug(&request)))]
+pub async fn get_graphql_handler(
 	_api_key: ApiKeyGuard<GraphqlApiKey>,
 	github_service: &State<Arc<dyn GithubService>>,
 	request: GraphQLRequest,
@@ -31,7 +33,8 @@ pub async fn get(
 }
 
 #[post("/graphql", data = "<request>")]
-pub async fn post(
+#[instrument(skip_all, fields(graphql_request = debug(&request)))]
+pub async fn post_graphql_handler(
 	_api_key: ApiKeyGuard<GraphqlApiKey>,
 	github_service: &State<Arc<dyn GithubService>>,
 	request: GraphQLRequest,


### PR DESCRIPTION
- 🔊 create trace when a graphql request is received
- 🔊 create trace when a graphql request is received on github-proxy
- 🔊 instrument projectors
- 🔊 propagate traces accros services
- ♻️ move UniqueMessage to common infrastructure
- 🔥 renove useless code
- 🔊 instrument Postgres connections
- 🔊 ensure errors occuring in graphql handler are logged
- 🔊 instrument usecases
- 🔊 instrument event store
- 🔊 instrument DieselRepository and DieselMappingRepository
