### PR TITLE
E 221 fix github cache

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -157,6 +157,20 @@
         {
             "type": "lldb",
             "request": "launch",
+            "name": "Debug executable 'github-proxy'",
+            "cargo": {
+                "args": ["build", "--bin=github-proxy", "--package=github-proxy"],
+                "filter": {
+                    "name": "github-proxy",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
             "name": "Debug unit tests in executable 'event-store'",
             "cargo": {
                 "args": [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1488,6 +1488,7 @@ dependencies = [
  "presentation",
  "reqwest",
  "rocket",
+ "rstest",
  "serde",
  "thiserror",
  "tracing",

--- a/backend/event-listeners/src/infrastructure/github/service.rs
+++ b/backend/event-listeners/src/infrastructure/github/service.rs
@@ -24,7 +24,9 @@ impl GithubService for github::Client {
 		let repo_id: i64 = (*github_repo_id).into();
 		let repo = self.get_repository_by_id(repo_id as u64).await?;
 
-		let languages: Value = if let Some(url) = repo.languages_url {
+		let languages: Value = if let Some(url) =
+			self.fix_github_host(&repo.languages_url).map_err(GithubServiceError::Other)?
+		{
 			self.get_as(url).await?
 		} else {
 			Default::default()

--- a/backend/github-proxy/Cargo.toml
+++ b/backend/github-proxy/Cargo.toml
@@ -40,3 +40,4 @@ olog = {path = "../common/olog"}
 domain = {path = "../common/domain"}
 
 [dev-dependencies]
+rstest = "0.15.0"

--- a/backend/github-proxy/src/infrastructure/github/service.rs
+++ b/backend/github-proxy/src/infrastructure/github/service.rs
@@ -25,7 +25,10 @@ impl GithubService for github::Client {
 	async fn fetch_repository_by_id(&self, id: u64) -> GithubServiceResult<GithubRepository> {
 		let repo = self.get_repository_by_id(id).await?;
 
-		let contributors: Contributors = match &repo.contributors_url {
+		let contributors: Contributors = match self
+			.fix_github_host(&repo.contributors_url)
+			.map_err(GithubServiceError::Other)?
+		{
 			Some(url) => self.get_as(url).await?,
 			None => Default::default(),
 		};

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,7 +94,6 @@ services:
       AUTH_LOG_LEVEL: info
       AUTH_CLIENT_URL: http://localhost:5173/login
       AUTH_PROVIDER_GITHUB_ENABLED: "true"
-      AUTH_PROVIDER_GITHUB_SCOPE: user
       AUTH_SERVER_URL: http://localhost:4000
       AUTH_PROVIDER_GITHUB_CLIENT_ID: ${AUTH_PROVIDER_GITHUB_CLIENT_ID:-my_github_client_id}
       AUTH_PROVIDER_GITHUB_CLIENT_SECRET: ${AUTH_PROVIDER_GITHUB_CLIENT_SECRET:-my_github_client_secret}


### PR DESCRIPTION
Please read comments in E-221 to understand what this pr fixes.

- 🐛 override Cache-Control header in github reverse proxy to allow caching
- 🐛 fix Github urls when they are taken dynamically from Github responses
- 🔨 update Docker config to match production

Closes E-221