### PR TITLE
E-244 Fix bug when typing 2 links in PR input

### DIFF
--- a/frontend/src/pages/ProjectDetails/PaymentActions/PaymentForm/PaymentForm.test.tsx
+++ b/frontend/src/pages/ProjectDetails/PaymentActions/PaymentForm/PaymentForm.test.tsx
@@ -159,6 +159,10 @@ describe.each([
   { link: "https://github.com/onlydustxyz/marketplace/issues/504", shouldMatch: false },
   { link: "https://github.com/onlydustxyz/pull/504", shouldMatch: false },
   { link: "https://github.com/onlydustxyz/marketplace/pull/", shouldMatch: false },
+  {
+    link: "https://github.com/onlydustxyz/marketplace/pull/504, https://github.com/onlydustxyz/marketplace/pull/505",
+    shouldMatch: false,
+  },
   { link: "not-a-link", shouldMatch: false },
 ])("Github PR validation regexp", ({ link, shouldMatch }) => {
   test(`should ${shouldMatch ? "" : "not "}match link '${link}'`, async () => {

--- a/frontend/src/pages/ProjectDetails/PaymentActions/PaymentForm/index.tsx
+++ b/frontend/src/pages/ProjectDetails/PaymentActions/PaymentForm/index.tsx
@@ -13,7 +13,7 @@ import { debounce } from "lodash";
 
 const DEFAULT_NUMBER_OF_DAYS = 2;
 
-export const REGEX_VALID_GITHUB_PULL_REQUEST_URL = /https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/pull\/\d+/;
+export const REGEX_VALID_GITHUB_PULL_REQUEST_URL = /^https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/pull\/\d+$/;
 
 interface PaymentFormProps {
   projectId: string;


### PR DESCRIPTION
- 🐛 The "Link to GitHub issue" input must accept only one link
