### PR TITLE
👷 run chromatic when pushing an epic branch

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - "main"
       - "hotfix/**"
+      - "epic/**"
 
 jobs:
   chromatic-deployment:


### PR DESCRIPTION
I created a fake epic branch for this in order to test it. 
By running chromatic when an epic branch is pushed, we should be able to see the changeset in chromatic UI as a baseline will have been generated.