### PR TITLE
🐛 react properly to RabbitMQ connection loss

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1922,6 +1922,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "tokio-retry",
  "tokio-stream",
  "tracing",
  "tracing-opentelemetry",
@@ -4146,6 +4147,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-retry"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+dependencies = [
+ "pin-project",
+ "rand 0.8.5",
  "tokio",
 ]
 

--- a/backend/api/app.yaml
+++ b/backend/api/app.yaml
@@ -9,6 +9,9 @@ default:
       api-key: $GITHUB_PROXY_GITHUB_API_KEY
   web3:
     url: https://mainnet.infura.io/v3/$INFURA_API_KEY
+  amqp:
+    connection_retry_interval_ms: 6000
+    connection_retry_count: 100
 
 local:
   database:

--- a/backend/api/src/bin/events_sanity_checks/app.yaml
+++ b/backend/api/src/bin/events_sanity_checks/app.yaml
@@ -13,6 +13,9 @@ default:
     json: false
     ansi: true
     location: false
+  amqp:
+    connection_retry_interval_ms: 6000
+    connection_retry_count: 100
 
 local:
   database:

--- a/backend/api/src/main.rs
+++ b/backend/api/src/main.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<()> {
 	http::serve(
 		config.http().clone(),
 		graphql::create_schema(),
-		Arc::new(amqp::Bus::default(config.amqp()).await?),
+		Arc::new(amqp::Bus::new(config.amqp()).await?),
 		AggregateRootRepository::new(database.clone()),
 		ProjectDetailsRepository::new(database.clone()),
 		GithubRepoRepository::new(database.clone()),

--- a/backend/common/infrastructure/Cargo.toml
+++ b/backend/common/infrastructure/Cargo.toml
@@ -68,6 +68,7 @@ rand = "0.8.5"
 regex = "1.7.0"
 url = "2.2.2"
 lazy_static = "1.4.0"
+tokio-retry = "0.3"
 
 # Web3
 web3 = "0.18.0"

--- a/backend/common/infrastructure/src/amqp/bus.rs
+++ b/backend/common/infrastructure/src/amqp/bus.rs
@@ -7,6 +7,7 @@ use lapin::{
 use olog::error;
 use thiserror::Error;
 use tokio::sync::RwLock;
+use tokio_retry::{strategy::FixedInterval, Retry};
 use tokio_stream::StreamExt;
 
 use super::Config;
@@ -25,18 +26,46 @@ pub struct Bus {
 }
 
 impl Bus {
-	pub async fn new(connection: Connection) -> Result<Self, Error> {
-		let channel = connection.create_channel().await?;
+	/// Initalizes a new event bus by connecting to RabbitMQ and creating a new channel of
+	/// communication.
+	///
+	/// If it fails to connect to RabbitMQ, it will retry at fixed interval depending on the
+	/// configuration.
+	///
+	/// In case the connection to RabbitMQ is lost later during the execution of the
+	/// application, an error will be logged and the process will exit with code 1.
+	///
+	/// The combination of those two behaviors allows us to let Heroku restart the application as
+	/// soon as the connection is lost, while ensuring it doesn't crash again when it restarts (in
+	/// case RabbitMQ is still not reachable). Not doing the retry would potentially lead the
+	/// application to restart early again, and would make us enter the exponential backoff policy
+	/// of Heroku (the second restart can be delayed by up to 20 minutes (!!!) by Heroku).
+	pub async fn new(config: &Config) -> Result<Self, Error> {
+		let retry_strategy = FixedInterval::from_millis(*config.connection_retry_interval_ms())
+			.take(*config.connection_retry_count());
 
+		let connection = Retry::spawn(retry_strategy, || async {
+			Connection::connect(config.url(), Default::default()).await.map_err(|error| {
+				error!(
+					"Failed to connect to RabbitMQ: {error:?}. Retrying in {}ms for a maximum of {} attempts.",
+					config.connection_retry_interval_ms(),
+					config.connection_retry_count()
+				);
+				error
+			})
+		})
+		.await?;
+
+		connection.on_error(|error| {
+			error!("Lost connection to RabbitMQ: {error:?}");
+			std::process::exit(1);
+		});
+
+		let channel = connection.create_channel().await?;
 		Ok(Self {
 			_connection: connection,
 			channel,
 		})
-	}
-
-	pub async fn default(config: &Config) -> Result<Self, Error> {
-		let connection = Connection::connect(config.url(), Default::default()).await?;
-		Self::new(connection).await
 	}
 
 	pub async fn with_queue(

--- a/backend/common/infrastructure/src/amqp/config.rs
+++ b/backend/common/infrastructure/src/amqp/config.rs
@@ -4,11 +4,21 @@ use serde::Deserialize;
 #[derive(Deserialize, Getters)]
 pub struct Config {
 	url: String,
+	connection_retry_interval_ms: u64,
+	connection_retry_count: usize,
 }
 
 #[cfg(test)]
 impl Config {
-	pub fn new(url: String) -> Self {
-		Self { url }
+	pub fn new(
+		url: String,
+		connection_retry_interval_ms: u64,
+		connection_retry_count: usize,
+	) -> Self {
+		Self {
+			url,
+			connection_retry_interval_ms,
+			connection_retry_count,
+		}
 	}
 }

--- a/backend/common/infrastructure/src/amqp/subscriber.rs
+++ b/backend/common/infrastructure/src/amqp/subscriber.rs
@@ -209,12 +209,12 @@ mod tests {
 	#[once]
 	fn config() -> Config {
 		// TODO: Find a better way to have a test configuration for integration tests
-		Config::new("amqp://127.0.0.1:5672/%2f".to_string())
+		Config::new("amqp://127.0.0.1:5672/%2f".to_string(), 200, 0)
 	}
 
 	#[fixture]
 	async fn bus(config: &Config) -> Bus {
-		Bus::default(config).await.unwrap()
+		Bus::new(config).await.unwrap()
 	}
 
 	#[rstest]

--- a/backend/common/infrastructure/src/event_bus.rs
+++ b/backend/common/infrastructure/src/event_bus.rs
@@ -10,7 +10,7 @@ pub async fn consumer(
 	config: &Config,
 	queue_name: &'static str,
 ) -> Result<ConsumableBus, BusError> {
-	let bus = Bus::default(config)
+	let bus = Bus::new(config)
 		.await?
 		.with_queue(
 			queue_name,

--- a/backend/event-listeners/app.yaml
+++ b/backend/event-listeners/app.yaml
@@ -4,6 +4,9 @@ default:
     personal_access_tokens: $GITHUB_PAT
     headers:
       api-key: $GITHUB_PROXY_GITHUB_API_KEY
+  amqp:
+    connection_retry_interval_ms: 6000
+    connection_retry_count: 100
 
 local:
   database:

--- a/backend/event-listeners/src/bin/refresh/app.yaml
+++ b/backend/event-listeners/src/bin/refresh/app.yaml
@@ -8,6 +8,9 @@ default:
     json: false
     ansi: true
     location: false
+  amqp:
+    connection_retry_interval_ms: 6000
+    connection_retry_count: 1
 
 local:
   database:

--- a/backend/event-store/app.yaml
+++ b/backend/event-store/app.yaml
@@ -1,3 +1,8 @@
+default:
+  amqp:
+    connection_retry_interval_ms: 6000
+    connection_retry_count: 100
+
 local:
   database:
     url: postgres://postgres:postgres@localhost/marketplace_db

--- a/backend/event-store/src/bus.rs
+++ b/backend/event-store/src/bus.rs
@@ -5,7 +5,7 @@ use olog::info;
 pub const QUEUE_NAME: &str = "event-store";
 
 pub async fn consumer(config: &Config) -> Result<ConsumableBus, BusError> {
-	let event_bus = Bus::default(config)
+	let event_bus = Bus::new(config)
 		.await?
 		.with_queue(
 			QUEUE_NAME,

--- a/backend/event-store/src/main.rs
+++ b/backend/event-store/src/main.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<()> {
 	let _tracer = Tracer::init(&config.tracer, "event_store")?;
 
 	let inbound_event_bus = bus::consumer(&config.amqp).await?;
-	let outbound_event_bus = Arc::new(Bus::default(&config.amqp).await?);
+	let outbound_event_bus = Arc::new(Bus::new(&config.amqp).await?);
 	let database = Arc::new(DatabaseClient::new(init_pool(&config.database)?));
 
 	inbound_event_bus


### PR DESCRIPTION
FYI: https://devcenter.heroku.com/articles/dynos#dyno-crash-restart-policy