### PR TITLE
show confirmation/error toaster for mutation

### DIFF
--- a/frontend/src/components/PayoutTable/PaymentRequestSidePanel/index.tsx
+++ b/frontend/src/components/PayoutTable/PaymentRequestSidePanel/index.tsx
@@ -6,6 +6,8 @@ import { HasuraUserRole, PaymentStatus } from "src/types";
 import { IssueDetailsFragmentDoc, PaymentRequestDetailsQuery } from "src/__generated/graphql";
 import View from "./View";
 import usePaymentRequests from "src/hooks/usePaymentRequests";
+import { useShowToaster } from "src/hooks/useToaster";
+import { useIntl } from "src/hooks/useIntl";
 
 type Props = {
   projectId?: string;
@@ -26,6 +28,9 @@ export default function PaymentRequestSidePanel({ projectId, paymentId, projectL
     }
   );
 
+  const showToaster = useShowToaster();
+  const { T } = useIntl();
+
   const status =
     data?.paymentRequestsByPk?.paymentsAggregate.aggregate?.sum?.amount === data?.paymentRequestsByPk?.amountInUsd
       ? PaymentStatus.ACCEPTED
@@ -37,7 +42,14 @@ export default function PaymentRequestSidePanel({ projectId, paymentId, projectL
 
   const { cancelPaymentRequest } = usePaymentRequests(projectId);
 
-  const onPaymentCancel = () => cancelPaymentRequest({ variables: { paymentId }, onCompleted: () => setOpen(false) });
+  const onPaymentCancel = () =>
+    cancelPaymentRequest({
+      variables: { paymentId },
+      onCompleted: () => {
+        setOpen(false);
+        showToaster(T("payment.form.cancelled"));
+      },
+    });
 
   return (
     <View

--- a/frontend/src/hooks/usePaymentRequests/index.ts
+++ b/frontend/src/hooks/usePaymentRequests/index.ts
@@ -26,6 +26,7 @@ export default function usePaymentRequests(projectId?: string) {
 
   const [requestNewPayment] = useHasuraMutation(RequestPaymentDocument, HasuraUserRole.RegisteredUser, {
     variables: { projectId },
+    context: { graphqlErrorDisplay: "toaster" },
     update: (cache, result, { variables }) => {
       const { budgetId, paymentId, amount } = (result as RequestPaymentMutationResult).data?.requestPayment || {};
       const { contributorId, reason } = variables as RequestPaymentMutationVariables;
@@ -55,6 +56,7 @@ export default function usePaymentRequests(projectId?: string) {
 
   const [cancelPaymentRequest] = useHasuraMutation(CancelPaymentRequestDocument, HasuraUserRole.RegisteredUser, {
     variables: { projectId },
+    context: { graphqlErrorDisplay: "toaster" },
     update: (cache, result) => {
       const { budgetId, paymentId, amount } =
         (result as CancelPaymentRequestMutationResult).data?.cancelPaymentRequest || {};

--- a/frontend/src/pages/Payments/InvoiceSubmission/index.tsx
+++ b/frontend/src/pages/Payments/InvoiceSubmission/index.tsx
@@ -27,8 +27,8 @@ export default function InvoiceSubmission({ paymentRequests, githubUserId, userI
     HasuraUserRole.RegisteredUser,
     {
       variables: { paymentReferences: paymentRequests.map(p => ({ projectId: p.project?.id || "", paymentId: p.id })) },
+      context: { graphqlErrorDisplay: "toaster" },
       onCompleted: () => showToaster(T("invoiceSubmission.toaster.success")),
-      onError: () => showToaster(T("invoiceSubmission.toaster.error"), { isError: true }),
       update: (cache, _, { variables }) => {
         const { paymentReferences } = variables as MarkInvoiceAsReceivedMutationVariables;
         const paymentIds = Array.isArray(paymentReferences)

--- a/frontend/src/pages/ProjectDetails/Payments/PaymentForm/WorkItemSidePanel/Issues/useIgnoredIssues.ts
+++ b/frontend/src/pages/ProjectDetails/Payments/PaymentForm/WorkItemSidePanel/Issues/useIgnoredIssues.ts
@@ -20,6 +20,7 @@ export default function useIgnoredIssues(issues: WorkItem[]) {
     (projectId: string, workItem: WorkItem) =>
       ignoreIssue({
         variables: { projectId, repoId: workItem.repoId, issueNumber: workItem.number },
+        context: { graphqlErrorDisplay: "toaster" },
         onCompleted: () => add(workItem),
         update: cache =>
           cache.modify({
@@ -36,6 +37,7 @@ export default function useIgnoredIssues(issues: WorkItem[]) {
     (projectId: string, workItem: WorkItem) =>
       unignoreIssue({
         variables: { projectId, repoId: workItem.repoId, issueNumber: workItem.number },
+        context: { graphqlErrorDisplay: "toaster" },
         onCompleted: () => remove(workItem),
         update: cache =>
           cache.modify({

--- a/frontend/src/pages/ProjectDetails/Payments/PaymentForm/WorkItemSidePanel/OtherWorkForm/index.tsx
+++ b/frontend/src/pages/ProjectDetails/Payments/PaymentForm/WorkItemSidePanel/OtherWorkForm/index.tsx
@@ -83,6 +83,7 @@ export default function OtherWorkForm({ projectId, contributorHandle, onWorkItem
         description,
         assignees: [leader?.displayName, contributorHandle],
       } as CreateIssueMutationVariables,
+      context: { graphqlErrorDisplay: "toaster" },
       onCompleted: data => {
         clearForm();
         onWorkItemAdded(data.createIssue);

--- a/frontend/src/pages/ProjectDetails/index.tsx
+++ b/frontend/src/pages/ProjectDetails/index.tsx
@@ -38,7 +38,10 @@ const ProjectDetails: React.FC = () => {
 
   const [acceptInvitation, acceptInvitationResponse] = useHasuraMutation(
     ACCEPT_PROJECT_LEADER_INVITATION_MUTATION,
-    HasuraUserRole.RegisteredUser
+    HasuraUserRole.RegisteredUser,
+    {
+      context: { graphqlErrorDisplay: "toaster" },
+    }
   );
 
   const getProjectQuery = useCachableHasuraQuery<GetProjectQuery>(GET_PROJECT_QUERY, HasuraUserRole.Public, {

--- a/frontend/src/translations/en.json
+++ b/frontend/src/translations/en.json
@@ -190,6 +190,7 @@
       },
       "leftToSpend": "Left to spend",
       "remainingBudget": "Remaining budget",
+      "cancelled": "Payment request cancelled",
       "sent": "Payment successfully sent",
       "steps": {
         "days": {


### PR DESCRIPTION
- 💄 show confirmation toaster when cancelling a payment
- 🥅 use toaster for mutation errors
