### PR TITLE
Fix impersonation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,8 +11,6 @@ GITHUB_PROXY_GRAPHQL_API_KEY=mygithubproxyapikey
 DUSTY_BOT_GRAPHQL_API_KEY=mdustybotapikey
 INFURA_API_KEY=infura_key                                               # REPLACE_AT_INSTALLATION
 
-IMPERSONATION_SECRET=myimpersonationsecret
-
 # Logs
 RUST_LOG=info
 

--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,8 @@ GITHUB_PROXY_GRAPHQL_API_KEY=mygithubproxyapikey
 DUSTY_BOT_GRAPHQL_API_KEY=mdustybotapikey
 INFURA_API_KEY=infura_key                                               # REPLACE_AT_INSTALLATION
 
+IMPERSONATION_SECRET=myimpersonationsecret
+
 # Logs
 RUST_LOG=info
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3514,6 +3514,7 @@ dependencies = [
  "domain",
  "envtestkit",
  "jsonwebtoken",
+ "olog",
  "rocket",
  "rstest",
  "serde",

--- a/backend/common/presentation/Cargo.toml
+++ b/backend/common/presentation/Cargo.toml
@@ -35,6 +35,7 @@ derive-getters = "0.2.0"
 
 # Local dependecies
 domain = {path = "../domain"}
+olog = {path = "../olog"}
 
 [dev-dependencies]
 async-std = {version = "1.12.0", features = ["attributes"]}

--- a/frontend/src/providers/ApolloWrapper/links/authentication.ts
+++ b/frontend/src/providers/ApolloWrapper/links/authentication.ts
@@ -8,14 +8,26 @@ export default function useAuthenticationLink() {
 
   return setContext((_, { headers }) => {
     const authorizationHeaders = tokenSet?.accessToken ? { Authorization: `Bearer ${tokenSet?.accessToken}` } : {};
-    const impersonationHeaders = impersonationSet
+    const impersonationClaims = impersonationSet
       ? {
-          "X-Hasura-Admin-Secret": impersonationSet.password,
-          "X-Hasura-User-Id": impersonationSet.userId,
-          "X-Hasura-projectsLeaded": `{${customClaims.projectsLeaded?.map(id => `"${id}"`).join(",")}}`,
-          "X-Hasura-githubUserId": customClaims.githubUserId,
+          "x-hasura-user-id": impersonationSet.userId,
+          "x-hasura-projectsLeaded": `{${customClaims.projectsLeaded?.map(id => `"${id}"`).join(",")}}`,
+          "x-hasura-githubUserId": `${customClaims.githubUserId}`,
         }
-      : {};
+      : undefined;
+    const impersonationHeaders =
+      impersonationSet && impersonationClaims
+        ? {
+            // Impersonation for Hasura
+            "X-Hasura-Admin-Secret": impersonationSet.password,
+            "X-Hasura-User-Id": impersonationClaims["x-hasura-user-id"],
+            "X-Hasura-projectsLeaded": impersonationClaims["x-hasura-projectsLeaded"],
+            "X-Hasura-githubUserId": impersonationClaims["x-hasura-githubUserId"],
+            // Impersonation for OnlyDust API
+            "X-Impersonation-Secret": impersonationSet.password,
+            "X-Impersonation-Claims": JSON.stringify(impersonationClaims),
+          }
+        : {};
     return {
       headers: {
         ...headers,

--- a/playwright/impersonate.spec.ts
+++ b/playwright/impersonate.spec.ts
@@ -5,13 +5,14 @@ import { BrowseProjectsPage } from "./pages/browse_projects_page";
 import { GenericPage } from "./pages/generic_page";
 import { RewardsPage } from "./pages/my_rewards_page";
 import { ImpersonationPage } from "./pages/impersonation_page";
+import { ViewProfilePage } from "./pages/profile/view_profile";
 
 test.describe("As an admin, I", () => {
   test.beforeAll(async () => {
     restoreDB();
   });
 
-  test("can impersonate a user", async ({ page, users }) => {
+  test("can impersonate a user", async ({ context, page, users }) => {
     const browseProjectsPage = new BrowseProjectsPage(page);
     await browseProjectsPage.goto();
 
@@ -32,9 +33,24 @@ test.describe("As an admin, I", () => {
     await expect(rewardsPage.sidePanel).toContainText("to");
     await expect(rewardsPage.sidePanel).toContainText(users.Olivier.github.login);
     await expect(rewardsPage.sidePanel).toContainText("(you)");
+
+    // Edit profile of impersonated user
+    new BrowseProjectsPage(page).goto();
+    const viewPage = new ViewProfilePage(page, context);
+    await viewPage.goto();
+    await expect(viewPage.login).toHaveText(users.Olivier.github.login);
+    await expect(viewPage.bio).not.toHaveText("MjMtNDY3MS05YjZjLTNhNWExODc0OGFmOSIsIng");
+
+    const editPage = await viewPage.edit();
+    await expect(editPage.login).toHaveText(users.Olivier.github.login);
+    await editPage.bio.fill("MjMtNDY3MS05YjZjLTNhNWExODc0OGFmOSIsIng");
+    await editPage.save();
+
+    await expect(viewPage.bio).toHaveText("MjMtNDY3MS05YjZjLTNhNWExODc0OGFmOSIsIng");
   });
 
   test("retain the login state when impersonating", async ({
+    context,
     page,
     users,
     signIn,
@@ -51,8 +67,28 @@ test.describe("As an admin, I", () => {
     await impersonationPage.submitForm();
     await appPage.expectToBeImpersonating(users.Olivier);
 
+    // Edit profile of impersonated user
+    new BrowseProjectsPage(page).goto();
+    const viewPage = new ViewProfilePage(page, context);
+    await viewPage.goto();
+    await expect(viewPage.login).toHaveText(users.Olivier.github.login);
+    await expect(viewPage.bio).not.toHaveText("C1oYXN1cmEtdXNlci1pZCI6ImU0NjFjMDE5LWJh");
+
+    const editPage = await viewPage.edit();
+    await expect(editPage.login).toHaveText(users.Olivier.github.login);
+    await editPage.bio.fill("C1oYXN1cmEtdXNlci1pZCI6ImU0NjFjMDE5LWJh");
+    await editPage.save();
+
+    await expect(viewPage.bio).toHaveText("C1oYXN1cmEtdXNlci1pZCI6ImU0NjFjMDE5LWJh");
+
     await logout();
     await appPage.expectToBeLoggedInAs(users.Anthony);
+
+    // Check Anthony's profile has not changed
+    new BrowseProjectsPage(page).goto();
+    await viewPage.goto();
+    await expect(viewPage.login).toHaveText(users.Anthony.github.login);
+    await expect(viewPage.bio).not.toHaveText("C1oYXN1cmEtdXNlci1pZCI6ImU0NjFjMDE5LWJh");
 
     await logout();
     await appPage.expectToBeAnonymous();

--- a/playwright/impersonate.spec.ts
+++ b/playwright/impersonate.spec.ts
@@ -81,6 +81,7 @@ test.describe("As an admin, I", () => {
 
     await expect(viewPage.bio).toHaveText("C1oYXN1cmEtdXNlci1pZCI6ImU0NjFjMDE5LWJh");
 
+    new BrowseProjectsPage(page).goto();
     await logout();
     await appPage.expectToBeLoggedInAs(users.Anthony);
 
@@ -90,6 +91,7 @@ test.describe("As an admin, I", () => {
     await expect(viewPage.login).toHaveText(users.Anthony.github.login);
     await expect(viewPage.bio).not.toHaveText("C1oYXN1cmEtdXNlci1pZCI6ImU0NjFjMDE5LWJh");
 
+    new BrowseProjectsPage(page).goto();
     await logout();
     await appPage.expectToBeAnonymous();
   });


### PR DESCRIPTION
Not a big fan of the solution, but it works.

The ugly parts also comes from the fact that we need to impersonate through BOTH our backend AND Hasura, which is why I used the `HASURA_GRAPHQL_ADMIN_SECRET` env var instead of adding a dedicated one.
