### PR TITLE
Fix impersonation and improve security

### DIFF
--- a/frontend/src/hooks/useAuth/useImpersonation.ts
+++ b/frontend/src/hooks/useAuth/useImpersonation.ts
@@ -13,6 +13,7 @@ export const useImpersonation = () => {
   const impersonatedUserQuery = useImpersonatedUserQuery({
     context: {
       graphqlErrorDisplay: "none",
+      headers: { "X-Hasura-Role": "admin" },
     },
     variables: {
       id: impersonationSet?.userId,

--- a/frontend/src/providers/ApolloWrapper/links/authentication.ts
+++ b/frontend/src/providers/ApolloWrapper/links/authentication.ts
@@ -20,6 +20,7 @@ export default function useAuthenticationLink() {
         ? {
             // Impersonation for Hasura
             "X-Hasura-Admin-Secret": impersonationSet.password,
+            "X-Hasura-Role": "registered_user",
             "X-Hasura-User-Id": impersonationClaims["x-hasura-user-id"],
             "X-Hasura-projectsLeaded": impersonationClaims["x-hasura-projectsLeaded"],
             "X-Hasura-githubUserId": impersonationClaims["x-hasura-githubUserId"],
@@ -30,9 +31,9 @@ export default function useAuthenticationLink() {
         : {};
     return {
       headers: {
-        ...headers,
         ...authorizationHeaders,
         ...impersonationHeaders,
+        ...headers,
       },
     };
   });


### PR DESCRIPTION
Roles are now determined from claims instead of using Hasura headers in order to be consistent.

😱 Impersonation now really impersonate a user by not pretending to be an admin (this bug was actually quite dangerous). See 2nd commit.