### PR TITLE
Improve impersonation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3512,7 +3512,6 @@ dependencies = [
  "async-trait",
  "derive-getters",
  "domain",
- "envtestkit",
  "jsonwebtoken",
  "olog",
  "rocket",
@@ -3520,7 +3519,9 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with 3.0.0",
+ "temp-env",
  "thiserror",
+ "tracing",
  "url",
  "uuid 1.3.3",
 ]
@@ -4857,6 +4858,16 @@ dependencies = [
  "p12",
  "rustls-connector",
  "rustls-pemfile",
+]
+
+[[package]]
+name = "temp-env"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9547444bfe52cbd79515c6c8087d8ae6ca8d64d2d31a27746320f5cb81d1a15c"
+dependencies = [
+ "futures",
+ "parking_lot 0.12.1",
 ]
 
 [[package]]

--- a/backend/common/infrastructure/src/database/schema.rs
+++ b/backend/common/infrastructure/src/database/schema.rs
@@ -51,6 +51,7 @@ diesel::table! {
         login_at_signup -> Text,
         avatar_url_at_signup -> Nullable<Text>,
         created_at -> Timestamp,
+        admin -> Bool,
     }
 }
 

--- a/backend/common/presentation/Cargo.toml
+++ b/backend/common/presentation/Cargo.toml
@@ -30,6 +30,9 @@ serde = {version = "1.0.137", features = ["derive"]}
 serde_json = {version = "1.0.81"}
 serde_with = "3.0.0"
 
+# Tracing
+tracing = "0.1"
+
 # Utils
 derive-getters = "0.2.0"
 
@@ -41,4 +44,4 @@ olog = {path = "../olog"}
 async-std = {version = "1.12.0", features = ["attributes"]}
 rstest = "0.15.0"
 assert_matches = "1.5"
-envtestkit = "1.1.2"
+temp-env = {version = "0.3.4", features = ["async_closure"]}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,15 +14,7 @@ services:
       - db:/var/lib/postgresql/data
       - ./scripts/initdb.d:/docker-entrypoint-initdb.d:ro
     healthcheck:
-      test:
-        [
-          "CMD",
-          "pg_isready",
-          "-d",
-          "marketplace_db",
-          "-U",
-          "postgres"
-        ]
+      test: ["CMD", "pg_isready", "-d", "marketplace_db", "-U", "postgres"]
       interval: 2s
       timeout: 1s
       retries: 20
@@ -97,7 +89,7 @@ services:
       HASURA_GRAPHQL_GRAPHQL_URL: http://hasura:8080/v1/graphql
       HASURA_GRAPHQL_ADMIN_SECRET: ${HASURA_GRAPHQL_ADMIN_SECRET:-myadminsecretkey}
       AUTH_ACCESS_TOKEN_EXPIRES_IN: 604800 # 1 week
-      AUTH_JWT_CUSTOM_CLAIMS: '{"projectsLeaded":"registeredUser.projectsLeaded[].projectId","githubUserId":"registeredUser.githubUserId","githubAccessToken":"userGithubProvider.accessToken"}'
+      AUTH_JWT_CUSTOM_CLAIMS: '{"projectsLeaded":"registeredUser.projectsLeaded[].projectId","githubUserId":"registeredUser.githubUserId","odAdmin":"registeredUser.admin","githubAccessToken":"userGithubProvider.accessToken"}'
       AUTH_USER_DEFAULT_ALLOWED_ROLES: public,me,registered_user
       AUTH_USER_DEFAULT_ROLE: registered_user
       AUTH_LOG_LEVEL: info

--- a/frontend/src/App/OnboardingProvider/index.tsx
+++ b/frontend/src/App/OnboardingProvider/index.tsx
@@ -18,7 +18,7 @@ export default function OnboardingProvider({ children }: PropsWithChildren) {
 
   const { data, loading } = useGetOnboardingStateQuery({
     variables: { userId },
-    skip: !userId,
+    skip: !userId || impersonating,
   });
 
   const location = useLocation();
@@ -34,11 +34,11 @@ export default function OnboardingProvider({ children }: PropsWithChildren) {
 
   const onboardingInProgress = onboardingRoutes.includes(location.pathname);
 
-  const skipRedirection = onboardingInProgress || !userId || loading || impersonating;
+  const skipRedirection = onboardingInProgress || !userId || loading;
 
-  return !skipRedirection && !onboardingWizzardCompleted ? (
+  return !skipRedirection && !onboardingWizzardCompleted && !impersonating ? (
     <Navigate to={generatePath(RoutePaths.Onboarding)} />
-  ) : !skipRedirection && !termsAndConditionsAccepted ? (
+  ) : !skipRedirection && !termsAndConditionsAccepted && !impersonating ? (
     <Navigate
       to={generatePath(RoutePaths.TermsAndConditions)}
       state={{ skipIntro: location.state?.onboardingWizzardCompleted }}

--- a/frontend/src/hooks/useImpersonationClaims.tsx
+++ b/frontend/src/hooks/useImpersonationClaims.tsx
@@ -51,7 +51,6 @@ export const ImpersonationClaimsProvider = ({ children }: PropsWithChildren) => 
           "X-Hasura-projectsLeaded": impersonationClaims["x-hasura-projectsLeaded"],
           "X-Hasura-githubUserId": impersonationClaims["x-hasura-githubUserId"],
           // Impersonation for OnlyDust API
-          "X-Impersonation-Secret": impersonationSet.password,
           "X-Impersonation-Claims": JSON.stringify(impersonationClaims),
         }
       : [];

--- a/frontend/src/pages/Impersonation/index.tsx
+++ b/frontend/src/pages/Impersonation/index.tsx
@@ -4,6 +4,7 @@ import { RoutePaths } from "src/App";
 import { Toaster } from "src/components/Toaster";
 import { useAuth } from "src/hooks/useAuth";
 import { useImpersonationClaims } from "src/hooks/useImpersonationClaims";
+import { useTokenSet } from "src/hooks/useTokenSet";
 import PasswordForm from "src/pages/Impersonation/PasswordForm";
 
 const ImpersonationPage = () => {
@@ -11,6 +12,11 @@ const ImpersonationPage = () => {
   const navigate = useNavigate();
   const { setImpersonationSet, clearImpersonationSet } = useImpersonationClaims();
   const { invalidImpersonation, impersonating } = useAuth();
+  const { tokenSet } = useTokenSet();
+
+  if (!tokenSet?.accessToken) {
+    navigate(RoutePaths.Projects);
+  }
 
   const onPasswordSubmit = (password: string) => {
     if (userId) {

--- a/migrations/2023-07-27-100339_add-admin-to-auth-users/down.sql
+++ b/migrations/2023-07-27-100339_add-admin-to-auth-users/down.sql
@@ -1,0 +1,20 @@
+DROP VIEW registered_users;
+
+
+ALTER TABLE auth_users
+DROP COLUMN "admin";
+
+
+CREATE VIEW
+    registered_users AS
+SELECT
+    au.id,
+    au.github_user_id,
+    COALESCE(gu.login, au.login_at_signup) AS login,
+    COALESCE(gu.avatar_url, au.avatar_url_at_signup) AS avatar_url,
+    COALESCE(gu.html_url, 'https://github.com/'::TEXT || au.login_at_signup) AS html_url,
+    au.email,
+    au.last_seen
+FROM
+    auth_users au
+    LEFT JOIN github_users gu ON gu.id = au.github_user_id;

--- a/migrations/2023-07-27-100339_add-admin-to-auth-users/up.sql
+++ b/migrations/2023-07-27-100339_add-admin-to-auth-users/up.sql
@@ -1,0 +1,21 @@
+ALTER TABLE auth_users
+ADD COLUMN "admin" BOOLEAN NOT NULL DEFAULT FALSE;
+
+
+DROP VIEW registered_users;
+
+
+CREATE VIEW
+    registered_users AS
+SELECT
+    au.id,
+    au.github_user_id,
+    COALESCE(gu.login, au.login_at_signup) AS login,
+    COALESCE(gu.avatar_url, au.avatar_url_at_signup) AS avatar_url,
+    COALESCE(gu.html_url, 'https://github.com/'::TEXT || au.login_at_signup) AS html_url,
+    au.email,
+    au.last_seen,
+    au."admin"
+FROM
+    auth_users au
+    LEFT JOIN github_users gu ON gu.id = au.github_user_id;

--- a/playwright/commands/db/db_utils.ts
+++ b/playwright/commands/db/db_utils.ts
@@ -34,3 +34,8 @@ export const indexerRunning = () => {
 
   return parseInt(count.toString());
 };
+
+export const setUserAsAdmin = (userId: string) => {
+  const DATABASE_URL = getEnv("DATABASE_URL");
+  execSync(`psql ${DATABASE_URL} -c "UPDATE public.auth_users SET admin=TRUE WHERE id='${userId}'"`, { stdio: "pipe" });
+};

--- a/playwright/commands/populate/populate_users.ts
+++ b/playwright/commands/populate/populate_users.ts
@@ -12,6 +12,7 @@ import {
 } from "../../__generated/graphql";
 import { mutateAsRegisteredUser } from "../common";
 import { createGithubUser, signinUser } from "../user";
+import { setUserAsAdmin } from "../db/db_utils";
 
 export const populateUsers = async (request: APIRequestContext): Promise<Record<string, User>> => {
   const populatedUsers = await Promise.all(Object.values(users).map(user => populateUser(request, user)));
@@ -36,6 +37,10 @@ const populateUser = async (request: APIRequestContext, user: UserFixture) => {
         mutation: MarkOnboardingAsCompletedDocument,
       }
     );
+  }
+
+  if (user.admin) {
+    setUserAsAdmin(credentials.userId);
   }
 
   return {

--- a/playwright/fixtures/data/users.ts
+++ b/playwright/fixtures/data/users.ts
@@ -72,6 +72,7 @@ export const users: Record<string, UserFixture> = {
   },
   Anthony: {
     email: "antho@foo-mail.org",
+    admin: true,
     github: {
       id: 43467246,
       login: "AnthonyBuisset",

--- a/playwright/types.ts
+++ b/playwright/types.ts
@@ -18,6 +18,7 @@ export type UserFixture = {
   };
   payoutInfo?: UserPayoutInfo;
   onboardingWizardCompleted?: boolean;
+  admin?: boolean;
 };
 
 export type UserPayoutInfo = {


### PR DESCRIPTION
=> Force the user to be connected to be able to impersonate someone.

=> The user must be an admin (I considered that for now we can just manually set who is an admin by setting it directly in the DB).

=> This allows to know in the backend WHO is impersonating someone. We log it, and most of all, it will be part of every traces :)

=> No more X-Impersonation-Secret, as the whole thing is now based on a special new JWT claim called x-hasura-odAdmin (which is set by Hasura-Auth).

- ✨ add "x-hasura-odAdmin" into JWT
- ♻️ use "admin" claim from JWT instead of X-Impersontation-Secret
- ♻️ do not send X-Impersonation-Secret anymore
- ✏️ typo and log
- ✅ update e2e tests
- 🐛 fix issue with terms and conditions while impersonating
- 🚸 redirect to homepage if not connected and trying to impersonate
- ✅ more e2e tests
