### PR TITLE
feat: contributions empty state re-word

### DIFF
--- a/frontend/src/translations/en.json
+++ b/frontend/src/translations/en.json
@@ -259,7 +259,7 @@
         "title": "Contributions",
         "emptyState": {
           "title": "Nothing to show",
-          "subtitle": "Add contributions using their links"
+          "subtitle": "We constantly look at updates on Github but it can take some time before refresh"
         }
       },
       "leftToSpend": "Left to spend",


### PR DESCRIPTION
https://linear.app/onlydust/issue/E-632/improve-placeholder-when-no-pr-issue-to-show-on-reward

### Problem 

Wording of contributions EmptyState was confusing when some PR/issues were not yet indexed by github  

### Solution 

Change the wording to imply there can be some waiting