### PR TITLE
[E-756] Fix input form for contributor contact info

### DIFF
--- a/frontend/src/pages/ProjectDetails/Overview/index.tsx
+++ b/frontend/src/pages/ProjectDetails/Overview/index.tsx
@@ -287,7 +287,7 @@ function ApplyCallout({ isLoggedIn, profile, alreadyApplied, applyToProject, dis
     if (JSON.stringify(values) !== JSON.stringify(fromFragment(profile))) {
       reset(fromFragment(profile));
     }
-  });
+  }, []);
 
   const [updateUserProfileInfo, { loading }] = useUpdateUserProfileMutation({
     context: { graphqlErrorDisplay: "toaster" },


### PR DESCRIPTION
### Problem 

We used to prefill contributor form with user profile information with a `useEffect` hook with no dependancies.
This hook was trigger on every form `onChange` thus preventing the user from completing the form.

### Solution 

Pass an empty dependancies Array 